### PR TITLE
Simplify archive writing by using anonymous structs.

### DIFF
--- a/writer/file_archiver.go
+++ b/writer/file_archiver.go
@@ -16,7 +16,6 @@ package writer
 
 import (
 	"archive/tar"
-	"errors"
 	"os"
 )
 
@@ -24,7 +23,7 @@ import (
 type FileArchiver struct {
 	path string
 	name string
-	file *os.File
+	*os.File
 }
 
 // NewFileArchiver creates fileArchiver used for storing plain files
@@ -43,23 +42,8 @@ func (f *FileArchiver) Open() error {
 	if err != nil {
 		return err
 	}
-	f.file = fd
+	f.File = fd
 	return nil
-}
-
-func (f *FileArchiver) Read(p []byte) (n int, err error) {
-	if f.file == nil {
-		return 0, errors.New("attempt to read from closed file")
-	}
-	return f.file.Read(p)
-}
-
-// Close is a path of ReadArchiver interface
-func (f *FileArchiver) Close() error {
-	if f.file != nil {
-		return f.file.Close()
-	}
-	return errors.New("file already closed")
 }
 
 // GetHeader is a path of ReadArchiver interface. It returns tar.Header which

--- a/writer/stream_archiver.go
+++ b/writer/stream_archiver.go
@@ -24,9 +24,9 @@ import (
 
 // StreamArchiver implements ReadArchiver interface
 type StreamArchiver struct {
-	name   string
-	data   []byte
-	buffer *bytes.Buffer
+	name string
+	data []byte
+	*bytes.Buffer
 }
 
 // NewStreamArchiver creates streamArchiver used for storing plain text files
@@ -34,11 +34,7 @@ type StreamArchiver struct {
 // data is the plain data that will be stored in archive file
 // name is the relatve path inside the archive (see tar.Header.Name)
 func NewStreamArchiver(data []byte, name string) *StreamArchiver {
-	return &StreamArchiver{
-		name:   name,
-		data:   data,
-		buffer: bytes.NewBuffer(data),
-	}
+	return &StreamArchiver{name, data, bytes.NewBuffer(data)}
 }
 
 // NewJSONStreamArchiver creates streamArchiver used for storing JSON files
@@ -51,19 +47,11 @@ func NewJSONStreamArchiver(data metadata.Validater, name string) *StreamArchiver
 	if err != nil {
 		return nil
 	}
-	return &StreamArchiver{
-		name:   name,
-		data:   j,
-		buffer: bytes.NewBuffer(j),
-	}
+	return &StreamArchiver{name, j, bytes.NewBuffer(j)}
 }
 
 // Open is implemented as a path of ReadArchiver interface
 func (str *StreamArchiver) Open() error { return nil }
-
-func (str *StreamArchiver) Read(p []byte) (n int, err error) {
-	return str.buffer.Read(p)
-}
 
 // Close is implemented as a path of ReadArchiver interface
 func (str *StreamArchiver) Close() error { return nil }


### PR DESCRIPTION
Both FileArchiver and StreamArchiver are using annonymous
struct members to implement part of ReadArchiver interface.