### PR TITLE
Parser: GetImageID method

### DIFF
--- a/parser/rootfs_parser.go
+++ b/parser/rootfs_parser.go
@@ -62,6 +62,9 @@ func (rp *RootfsParser) GetUpdateFiles() map[string]UpdateFile {
 func (rp *RootfsParser) GetDeviceType() string {
 	return rp.metadata.Required.DeviceType
 }
+func (rp *RootfsParser) GetImageID() string {
+	return rp.metadata.Required.ImageID
+}
 func (rp *RootfsParser) GetMetadata() *metadata.AllMetadata {
 	return &rp.metadata.All
 }

--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -191,6 +191,9 @@ func TestReadSequence(t *testing.T) {
 
 	for _, p := range w {
 		assert.Equal(t, "vexpress-qemu", p.GetDeviceType())
+		if rp, ok := p.(*parser.RootfsParser); ok {
+			assert.Equal(t, "core-image-minimal-201608110900", rp.GetImageID())
+		}
 	}
 
 	data, err := ioutil.ReadFile(path.Join(updateTestDir, "my_update"))


### PR DESCRIPTION
New rootfs parser method - GetImageID.
Method similar to GetDeviceType.

Required metadata fields are DeviceType and ImageID.
There is GetDeviceType() method already, but there was no GetImageID() method.

Signed-off-by: Krzysztof Jaskiewicz <krzysztof.jaskiewicz@open-rnd.pl>