### PR TITLE
Support for passing incoming update data stream to the caller

### DIFF
--- a/parser/generic_parser.go
+++ b/parser/generic_parser.go
@@ -34,11 +34,6 @@ type GenericParser struct {
 	updates  map[string]UpdateFile
 }
 
-func NewGenericParser() Parser {
-	return &GenericParser{
-		updates: map[string]UpdateFile{}}
-}
-
 func (rp *GenericParser) GetUpdateType() *metadata.UpdateType {
 	return &metadata.UpdateType{Type: "generic"}
 }
@@ -86,6 +81,9 @@ func (rp *GenericParser) ParseHeader(tr *tar.Reader, hdr *tar.Header, hPath stri
 
 	switch {
 	case strings.Compare(relPath, "files") == 0:
+		if rp.updates == nil {
+			rp.updates = map[string]UpdateFile{}
+		}
 		if err = parseFiles(tr, rp.updates); err != nil {
 			return err
 		}
@@ -151,7 +149,7 @@ func parseData(r io.Reader, w io.Writer, uFiles map[string]UpdateFile) error {
 }
 
 func (rp *GenericParser) Copy() Parser {
-	return NewGenericParser()
+	return &GenericParser{}
 }
 
 // data files are stored in tar.gz format

--- a/parser/rootfs_parser.go
+++ b/parser/rootfs_parser.go
@@ -31,25 +31,18 @@ import (
 )
 
 type RootfsParser struct {
-	dataWriter io.Writer
-	scriptDir  string
+	W         io.Writer
+	ScriptDir string
 
 	metadata metadata.Metadata
 	updates  map[string]UpdateFile
 }
 
-func NewRootfsParser(w io.Writer, scriptDir string) *RootfsParser {
-	if w == nil {
-		w = ioutil.Discard
-	}
-	return &RootfsParser{
-		dataWriter: w,
-		scriptDir:  scriptDir,
-		updates:    map[string]UpdateFile{}}
-}
-
 func (rp *RootfsParser) Copy() Parser {
-	return NewRootfsParser(rp.dataWriter, rp.scriptDir)
+	return &RootfsParser{
+		W:         rp.W,
+		ScriptDir: rp.ScriptDir,
+	}
 }
 
 func (rp *RootfsParser) GetUpdateType() *metadata.UpdateType {
@@ -169,6 +162,7 @@ func (rp *RootfsParser) ArchiveHeader(tw *tar.Writer,
 		return err
 	}
 
+	rp.updates = map[string]UpdateFile{}
 	for _, f := range updFiles {
 		rp.updates[withoutExt(f)] =
 			UpdateFile{
@@ -227,6 +221,9 @@ func (rp *RootfsParser) ParseHeader(tr *tar.Reader, hdr *tar.Header, hPath strin
 
 	switch {
 	case strings.Compare(relPath, "files") == 0:
+		if rp.updates == nil {
+			rp.updates = map[string]UpdateFile{}
+		}
 		if err = parseFiles(tr, rp.updates); err != nil {
 			return err
 		}
@@ -253,7 +250,7 @@ func (rp *RootfsParser) ParseHeader(tr *tar.Reader, hdr *tar.Header, hPath strin
 
 // data files are stored in tar.gz format
 func (rp *RootfsParser) ParseData(r io.Reader) error {
-	return parseData(r, rp.dataWriter, rp.updates)
+	return parseData(r, rp.W, rp.updates)
 }
 
 var hFormatPreWrite = metadata.ArtifactHeader{

--- a/parser/rootfs_parser.go
+++ b/parser/rootfs_parser.go
@@ -36,10 +36,13 @@ import (
 // occur.
 type DataHandlerFunc func(r io.Reader, dt string, uf UpdateFile) error
 
+// RootfsParser handles updates of type 'image-rootfs'. The parser can be
+// initialized setting `W` (io.Writer the update data gets written to), or
+// `DataFunc` (user provided callback that handlers the update data stream).
 type RootfsParser struct {
-	W         io.Writer
-	ScriptDir string
-	DataFunc  DataHandlerFunc
+	W         io.Writer       // output stream the update gets written to
+	ScriptDir string          // output directory for scripts
+	DataFunc  DataHandlerFunc // custom update data handler
 
 	metadata metadata.Metadata
 	updates  map[string]UpdateFile

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -52,7 +52,7 @@ func NewReader(r io.Reader) *Reader {
 		headerReader: &headerReader{},
 	}
 	// register generic parser so that basic parsing will always work
-	p := parser.NewGenericParser()
+	p := &parser.GenericParser{}
 	ar.SetGeneric(p)
 	return &ar
 }

--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -59,7 +59,7 @@ func writeArchive(dir string) (path string, err error) {
 	defer func() {
 		err = aw.Close()
 	}()
-	rp := parser.NewRootfsParser(nil, "")
+	rp := &parser.RootfsParser{}
 	aw.Register(rp)
 
 	path = filepath.Join(dir, "artifact.tar.gz")
@@ -84,7 +84,7 @@ func TestReadArchive(t *testing.T) {
 	assert.NotNil(t, f)
 
 	df, err := os.Create(path.Join(updateTestDir, "my_update"))
-	rp := parser.NewRootfsParser(df, "")
+	rp := &parser.RootfsParser{W: df}
 	defer df.Close()
 
 	aReader := NewReader(f)
@@ -135,7 +135,7 @@ func TestReadKnownUpdate(t *testing.T) {
 	assert.NotNil(t, f)
 
 	df, err := os.Create(filepath.Join(updateTestDir, "my_update"))
-	rp := parser.NewRootfsParser(df, "")
+	rp := &parser.RootfsParser{W: df}
 	defer df.Close()
 
 	aReader := NewReader(f)
@@ -161,7 +161,7 @@ func TestReadSequence(t *testing.T) {
 
 	aReader := NewReader(f)
 	defer aReader.Close()
-	rp := parser.NewRootfsParser(nil, "")
+	rp := &parser.RootfsParser{}
 	aReader.Register(rp)
 
 	info, err := aReader.ReadInfo()
@@ -177,7 +177,7 @@ func TestReadSequence(t *testing.T) {
 
 	for cnt, update := range hInfo.Updates {
 		if update.Type == "rootfs-image" {
-			rp := parser.NewRootfsParser(df, "")
+			rp := &parser.RootfsParser{W: df}
 			aReader.PushWorker(rp, fmt.Sprintf("%04d", cnt))
 		}
 	}

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -103,7 +103,7 @@ func TestWriteArtifactFile(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	rp := parser.NewRootfsParser(nil, "")
+	rp := &parser.RootfsParser{}
 	aw.Register(rp)
 
 	err = aw.Write(updateTestDir, filepath.Join(updateTestDir, "artifact.tar.gz"))
@@ -123,7 +123,7 @@ var dirStructOKSingle = []TestDirEntry{
 
 func TestWriteSingleArtifactFile(t *testing.T) {
 	updateTestDir, _ := ioutil.TempDir("", "update")
-	defer os.RemoveAll(updateTestDir)
+	//defer os.RemoveAll(updateTestDir)
 	err := MakeFakeUpdateDir(updateTestDir, dirStructOKSingle)
 	assert.NoError(t, err)
 
@@ -133,7 +133,7 @@ func TestWriteSingleArtifactFile(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	rp := parser.NewRootfsParser(nil, "")
+	rp := &parser.RootfsParser{}
 	aw.Register(rp)
 
 	err = aw.Write(updateTestDir, filepath.Join(updateTestDir, "artifact.tar.gz"))
@@ -180,7 +180,7 @@ func TestWriteMultiple(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	rp := parser.NewRootfsParser(nil, "")
+	rp := &parser.RootfsParser{}
 	aw.Register(rp)
 
 	err = aw.Write(updateTestDir, filepath.Join(updateTestDir, "artifact.tar.gz"))
@@ -238,7 +238,7 @@ func TestWriteCustom(t *testing.T) {
 		err = aw.Close()
 		assert.NoError(t, err)
 	}()
-	rp := parser.NewRootfsParser(nil, "")
+	rp := &parser.RootfsParser{}
 	aw.Register(rp)
 
 	err = aw.WriteSingle(filepath.Join(updateTestDir, "some_dir"),


### PR DESCRIPTION
The user of `RootfsParser` can provide `DataFunc` to receive a decompressed update data stream along with information about device type and current update.

Additional minor enhacements that remove the need for specialized `New..Parser`.

Do not merge yet, still missing tests.

@pasinskim @kacf 