### PR TITLE
Use the exact update type as a type-info parameter.

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -17,7 +17,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -73,11 +72,6 @@ func read(aPath string) (*areader.Reader, error) {
 	if ar == nil {
 		return nil, errors.New("Can not read artifact file.")
 	}
-
-	p := parser.RootfsParser{
-		W: ioutil.Discard, // don't store update anywhere
-	}
-	ar.Register(&p)
 
 	_, err = ar.Read()
 	if err != nil {

--- a/artifacts.go
+++ b/artifacts.go
@@ -91,7 +91,7 @@ func read(aPath string) (*areader.Reader, error) {
 func readArtifact(c *cli.Context) error {
 	if c.NArg() == 0 {
 		return errors.New("Nothing specified, nothing read. \nMaybe you wanted" +
-			"to say 'artifacts read <pathspec>'?")
+			" to say 'artifacts read <pathspec>'?")
 	}
 
 	r, err := read(c.Args().First())
@@ -126,7 +126,7 @@ func readArtifact(c *cli.Context) error {
 func validateArtifact(c *cli.Context) error {
 	if c.NArg() == 0 {
 		return errors.New("Nothing specified, nothing validated. \nMaybe you wanted" +
-			"to say 'artifacts validate <pathspec>'?")
+			" to say 'artifacts validate <pathspec>'?")
 	}
 
 	_, err := read(c.Args().First())

--- a/parser/generic_parser.go
+++ b/parser/generic_parser.go
@@ -168,8 +168,10 @@ func parseDataWithHandler(r io.Reader, handler parseDataHandlerFunc, uFiles map[
 	return nil
 }
 
+// Copy is implemented to satisfy Parser interface. We shouldn't allow
+// copying GenericParser as this one is created ad-hoc by `ParseManager`.
 func (rp *GenericParser) Copy() Parser {
-	return &GenericParser{}
+	return nil
 }
 
 // ParseData for generic parser is used ONLY for validating the integrity

--- a/parser/generic_parser.go
+++ b/parser/generic_parser.go
@@ -30,12 +30,13 @@ import (
 )
 
 type GenericParser struct {
-	metadata metadata.Metadata
-	updates  map[string]UpdateFile
+	metadata   metadata.Metadata
+	updates    map[string]UpdateFile
+	typeParsed string
 }
 
 func (rp *GenericParser) GetUpdateType() *metadata.UpdateType {
-	return &metadata.UpdateType{Type: "generic"}
+	return &metadata.UpdateType{Type: rp.typeParsed}
 }
 
 func (rp *GenericParser) GetUpdateFiles() map[string]UpdateFile {

--- a/parser/parser_manager.go
+++ b/parser/parser_manager.go
@@ -121,10 +121,10 @@ func (p *ParseManager) GetRegistered(parsingType string) (Parser, error) {
 	return parser.Copy(), nil
 }
 
+func (p *ParseManager) GetGeneric(parsingType string) Parser {
+	return &GenericParser{typeParsed: parsingType}
 func (p *ParseManager) SetGeneric(parser Parser) {
 	p.gParser = parser
 }
 
-func (p *ParseManager) GetGeneric() Parser {
-	return p.gParser
 }

--- a/parser/parser_manager.go
+++ b/parser/parser_manager.go
@@ -67,8 +67,6 @@ type Parser interface {
 }
 
 type ParseManager struct {
-	// generic parser for basic archive reading and validataing
-	gParser Parser
 	// list of registered parsers for specific types
 	pFactory map[string]Parser
 	// parser instances produced by factory to parse specific update type
@@ -79,7 +77,6 @@ type Workers map[string]Parser
 
 func NewParseManager() *ParseManager {
 	return &ParseManager{
-		nil,
 		make(map[string]Parser, 0),
 		make(Workers, 0),
 	}
@@ -123,8 +120,4 @@ func (p *ParseManager) GetRegistered(parsingType string) (Parser, error) {
 
 func (p *ParseManager) GetGeneric(parsingType string) Parser {
 	return &GenericParser{typeParsed: parsingType}
-func (p *ParseManager) SetGeneric(parser Parser) {
-	p.gParser = parser
-}
-
 }

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -46,15 +46,11 @@ type headerReader struct {
 }
 
 func NewReader(r io.Reader) *Reader {
-	ar := Reader{
+	return &Reader{
 		r:            r,
 		ParseManager: parser.NewParseManager(),
 		headerReader: &headerReader{hInfo: new(metadata.HeaderInfo)},
 	}
-	// register generic parser so that basic parsing will always work
-	p := &parser.GenericParser{}
-	ar.SetGeneric(p)
-	return &ar
 }
 
 func isCompatibleWithDevice(current string, compatible []string) bool {

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -194,7 +194,7 @@ func (ar *Reader) setWorkers() (parser.Workers, error) {
 		p, err := ar.ParseManager.GetRegistered(update.Type)
 		if err != nil {
 			// if there is no registered one; check if we can use generic
-			p = ar.ParseManager.GetGeneric()
+			p = ar.ParseManager.GetGeneric(update.Type)
 			if p == nil {
 				return nil, errors.Wrapf(err,
 					"reader: can not find parser for update type: [%v]", update.Type)


### PR DESCRIPTION
So far we've been returning the parser type as a update-type for a given update. This was correct for the specific update type parsing (like `rootfs-image`), as to use a given parser we need to have a match between parser parsing type and update type itself.
For the generic parser though, we've been returning `generic` as a given update type even though the exact type was different.
There are also some fixes and improvements added:
- missing space in error messages while using CLI tool
- always using `GenericParser` as a default parser type